### PR TITLE
Add support for more platforms

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,9 +21,15 @@ dependencies {
 
     implementation ( group = "com.aayushatharva.brotli4j", name = "brotli4j", version = "1.16.0" )
     runtimeOnly ( group = "com.aayushatharva.brotli4j", name = "native-windows-x86_64", version = "1.16.0" )
+    runtimeOnly ( group = "com.aayushatharva.brotli4j", name = "native-windows-aarch64", version = "1.16.0" )
     runtimeOnly ( group = "com.aayushatharva.brotli4j", name = "native-linux-x86_64", version = "1.16.0" )
     runtimeOnly ( group = "com.aayushatharva.brotli4j", name = "native-linux-aarch64", version = "1.16.0" )
+    runtimeOnly ( group = "com.aayushatharva.brotli4j", name = "native-linux-armv7", version = "1.16.0" )
+    runtimeOnly ( group = "com.aayushatharva.brotli4j", name = "native-linux-ppc64le", version = "1.16.0" )
+    runtimeOnly ( group = "com.aayushatharva.brotli4j", name = "native-linux-riscv64", version = "1.16.0" )
+    runtimeOnly ( group = "com.aayushatharva.brotli4j", name = "native-linux-s390x", version = "1.16.0" )
     runtimeOnly ( group = "com.aayushatharva.brotli4j", name = "native-osx-x86_64", version = "1.16.0" )
+    runtimeOnly ( group = "com.aayushatharva.brotli4j", name = "native-osx-aarch64", version = "1.16.0" )
 }
 
 tasks.shadowJar {


### PR DESCRIPTION
Since the jar size is not that big of an issue, it's possible to add the rest of native libraries from brotli4j

Size before and after:
3.13MB -> 7.04MB